### PR TITLE
Add isActive method to site

### DIFF
--- a/src/Orch/OrchSiteProvider.php
+++ b/src/Orch/OrchSiteProvider.php
@@ -175,6 +175,10 @@ class OrchSiteProvider extends SiteProvider
                 ArrayUtils::setByPath("Inf.SearchApi.Secret", $config, $kludgedEsSecret);
             }
 
+            // Kludged active state
+            $state = $responseBody["context"]["site"]["state"] ?? null;
+            ArrayUtils::setByPath("Garden.isActive", $config, $state === "active");
+
             return $config;
         });
 

--- a/src/Site.php
+++ b/src/Site.php
@@ -53,6 +53,16 @@ abstract class Site implements \JsonSerializable
     abstract protected function loadSiteConfig(): array;
 
     /**
+     * Return if a site is in an active state.
+     *
+     * @return bool
+     */
+    public function isActive(): bool
+    {
+        return $this->getConfigValueByKey("Vanilla.isActive", true);
+    }
+
+    /**
      * Get a site's ID.
      *
      * @return int


### PR DESCRIPTION
Add a method to `Garden\Sites\Site` to determine if a site is active or not. This will be used to exclude certain sites from cron jobs.