### PR TITLE
Add support for multisiteIDs - VNLA-4485

### DIFF
--- a/src/Local/LocalSiteProvider.php
+++ b/src/Local/LocalSiteProvider.php
@@ -75,7 +75,16 @@ class LocalSiteProvider extends SiteProvider
                     continue;
                 }
 
-                $siteRecord = new SiteRecord($siteID, $accountID, $clusterID, $baseUrl);
+                if (ArrayUtils::getByPath("EnabledPlugins.sitehubshared", $config) === true) {
+                    // we are a hub/node site.
+                    // Let's generate a multisiteID from the baseUrl
+                    $domain = parse_url($baseUrl, PHP_URL_HOST);
+                    $multisiteID = crc32($domain);
+                } else {
+                    $multisiteID = null;
+                }
+
+                $siteRecord = new SiteRecord($siteID, $accountID, $multisiteID, $clusterID, $baseUrl);
                 $configPath = str_replace($this->siteConfigFsBasePath, "", $configPath);
                 $siteRecord->setExtra("configPath", $configPath);
 

--- a/src/Mock/MockSite.php
+++ b/src/Mock/MockSite.php
@@ -36,23 +36,26 @@ class MockSite extends Site
      * @param int $siteID
      * @param array $config
      * @param string $clusterID
-     * @param MockSiteProvider|null $mockSiteProvider
+     * @param int $accountID
+     * @param int|null $multisiteID
      */
     public function __construct(
         string $baseUrl,
         int $siteID = MockSiteProvider::MOCK_SITE_ID,
         array $config = [],
         string $clusterID = self::MOCK_CLUSTER_ID,
-        MockSiteProvider $mockSiteProvider = null
+        int $accountID = 1,
+        ?int $multisiteID = null
     ) {
         $this->baseUrl = $baseUrl;
         $this->config = $config;
-        $siteRecord = new SiteRecord($siteID, 0, $clusterID, $baseUrl);
+        $siteRecord = new SiteRecord($siteID, $accountID, $multisiteID, $clusterID, $baseUrl);
         parent::__construct($siteRecord, new MockSiteProvider());
         $this->generateKey();
         $this->setSystemToken("test123");
         $this->setConfigs([
-            "Vanilla.AccountID" => 1,
+            "Vanilla.AccountID" => $accountID,
+            "Vanilla.SiteID" => $siteID,
             "queue.disableFeedback" => true,
         ]);
     }

--- a/src/Orch/OrchSiteProvider.php
+++ b/src/Orch/OrchSiteProvider.php
@@ -58,6 +58,7 @@ class OrchSiteProvider extends SiteProvider
             $site = new SiteRecord(
                 $apiSite["siteid"],
                 $apiSite["accountid"],
+                $apiSite["multisiteid"],
                 $apiSite["cluster"],
                 "https://" . $apiSite["baseurl"],
             );

--- a/src/Site.php
+++ b/src/Site.php
@@ -72,6 +72,16 @@ abstract class Site implements \JsonSerializable
         return $this->siteRecord->getAccountID();
     }
 
+    /**
+     * Get the multisiteID for the site. Only hub/node sites have a multisiteID.
+     *
+     * @return int|null
+     */
+    public function getMultisiteID(): ?int
+    {
+        return $this->siteRecord->getMultisiteID();
+    }
+
     /** Get the id of the cluster this site runs on.
      *
      * @return string

--- a/src/SiteProvider.php
+++ b/src/SiteProvider.php
@@ -131,6 +131,46 @@ abstract class SiteProvider
     }
 
     /**
+     * Get a list of sites associated with a particular account.
+     *
+     * @return TSite[]
+     */
+    public function getSitesByAccountID(int $accountID): array
+    {
+        /** @var TSite[] $sites */
+        $sites = [];
+
+        foreach ($this->getSites() as $site) {
+            if ($site->getAccountID() === $accountID) {
+                $sites[] = $site;
+            }
+        }
+
+        return $sites;
+    }
+
+    /**
+     * Get a list of sites associated with a hub/node.
+     *
+     * @param int $multisiteID
+     *
+     * @return TSite[]
+     */
+    public function getSitesByMultisiteID(int $multisiteID): array
+    {
+        /** @var TSite[] $sites */
+        $sites = [];
+
+        foreach ($this->getSites() as $site) {
+            if ($site->getMultisiteID() === $multisiteID) {
+                $sites[] = $site;
+            }
+        }
+
+        return $sites;
+    }
+
+    /**
      * @return array<int, TSite>
      */
     public function getSites(): array

--- a/src/SiteRecord.php
+++ b/src/SiteRecord.php
@@ -19,6 +19,8 @@ class SiteRecord implements \JsonSerializable
 
     private int $accountID;
 
+    private ?int $multisiteID;
+
     private string $clusterID;
 
     private string $baseUrl;
@@ -29,10 +31,11 @@ class SiteRecord implements \JsonSerializable
      * @param string $clusterID
      * @param string $baseUrl
      */
-    public function __construct(int $siteID, int $accountID, string $clusterID, string $baseUrl)
+    public function __construct(int $siteID, int $accountID, ?int $multisiteID, string $clusterID, string $baseUrl)
     {
         $this->siteID = $siteID;
         $this->accountID = $accountID;
+        $this->multisiteID = $multisiteID;
         $this->clusterID = $clusterID;
         $this->baseUrl = $baseUrl;
     }
@@ -51,6 +54,23 @@ class SiteRecord implements \JsonSerializable
     public function getAccountID(): int
     {
         return $this->accountID;
+    }
+
+    /**
+     * @return int|null
+     */
+    public function getMultisiteID(): ?int
+    {
+        return $this->multisiteID;
+    }
+
+    /**
+     * @param int|null $multisiteID
+     * @return void
+     */
+    public function setMultisiteID(?int $multisiteID): void
+    {
+        $this->multisiteID = $multisiteID;
     }
 
     /**

--- a/tests/Fixtures/ExpectedSite.php
+++ b/tests/Fixtures/ExpectedSite.php
@@ -29,9 +29,15 @@ class ExpectedSite extends SiteRecord
      * @param string $baseUrl
      * @param array $expectedConfigs
      */
-    public function __construct(int $siteID, int $accountID, string $clusterID, string $baseUrl, array $expectedConfigs)
-    {
-        parent::__construct($siteID, $accountID, $clusterID, $baseUrl);
+    public function __construct(
+        int $siteID,
+        int $accountID,
+        string $clusterID,
+        string $baseUrl,
+        array $expectedConfigs,
+        ?int $multisiteID = null
+    ) {
+        parent::__construct($siteID, $accountID, $multisiteID, $clusterID, $baseUrl);
         $this->expectedConfigs = $expectedConfigs;
     }
 
@@ -65,6 +71,7 @@ class ExpectedSite extends SiteRecord
         TestCase::assertEquals($this->getAccountID(), $site->getAccountID(), "Expected accountID {$suffix}.");
         TestCase::assertEquals($this->getClusterID(), $site->getClusterID(), "Expected clusterID {$suffix}.");
         TestCase::assertEquals($this->getBaseUrl(), $site->getBaseUrl(), "Expected baseUrl {$suffix}.");
+        TestCase::assertEquals($this->getMultisiteID(), $site->getMultisiteID(), "Expected multisiteID {$suffix}.");
     }
 
     /**

--- a/tests/LocalSitesTest.php
+++ b/tests/LocalSitesTest.php
@@ -8,7 +8,6 @@ namespace Garden\Sites\Tests;
 
 use Garden\Sites\Exceptions\ConfigLoadingException;
 use Garden\Sites\Local\LocalSiteProvider;
-use Garden\Sites\SiteProvider;
 use Garden\Sites\Tests\Fixtures\ExpectedSite;
 
 /**
@@ -21,6 +20,9 @@ class LocalSitesTest extends BaseSitesTestCase
     const SID_E2E = 102;
     const SID_NO_SYS_TOKEN = 103;
     const SID_OTHER_CLUSTER = 105;
+
+    const SID_HUB = 10000;
+    const SID_NODE1 = 10001;
 
     /**
      * @return array<int, ExpectedSite>
@@ -73,6 +75,22 @@ class LocalSitesTest extends BaseSitesTestCase
                 $commonConfig + [
                     "ClusterConfig.SomeKey" => "cluster2",
                 ],
+            ),
+            self::SID_HUB => new ExpectedSite(
+                self::SID_HUB,
+                10000,
+                "cl00000",
+                "http://vanilla.localhost/hub",
+                $commonConfig + [],
+                294952213, // crc32(vanilla.localhost)
+            ),
+            self::SID_NODE1 => new ExpectedSite(
+                self::SID_NODE1,
+                10000,
+                "cl00000",
+                "http://vanilla.localhost/node1",
+                $commonConfig + [],
+                294952213, // crc32(vanilla.localhost)
             ),
         ];
     }

--- a/tests/MockSitesTest.php
+++ b/tests/MockSitesTest.php
@@ -21,11 +21,36 @@ class MockSitesTest extends TestCase
     public function testSharedInstances()
     {
         $site1 = new MockSite("https://some-url.com", 1);
-        $site2 = new MockSite("https://some-url.com", 2);
+        $site2 = new MockSite("https://some-url.com", 2, ["foo" => ["bar" => true]], "cl00002", 5032, 100);
         $siteProvider = new MockSiteProvider($site1);
         $siteProvider->addSite($site2);
 
         $this->assertSame($site1, $siteProvider->getSite(1));
         $this->assertSame($site2, $siteProvider->getSite(2));
+
+        $this->assertEquals(true, $site2->getConfigValueByKey("foo.bar"));
+        $this->assertEquals(2, $site2->getSiteID());
+        $this->assertEquals(5032, $site2->getAccountID());
+        $this->assertEquals(100, $site2->getMultisiteID());
+        $this->assertEquals("cl00002", $site2->getClusterID());
+    }
+
+    /**
+     * @return void
+     */
+    public function testGetSitesFiltered()
+    {
+        $site1 = new MockSite("https://site1.com", 1, [], "cl00000", 100);
+        $site2 = new MockSite("https://company.com/site2", 2, [], "cl00000", 101, 500);
+        $site3 = new MockSite("https://company.com/site3", 3, [], "cl00000", 101, 500);
+        $site4 = new MockSite("https://site4.company.com", 4, [], "cl00000", 101);
+
+        $siteProvider = new MockSiteProvider($site1, $site2, $site3, $site4);
+
+        $this->assertEquals([$site1], $siteProvider->getSitesByAccountID(100));
+        $this->assertEquals([$site2, $site3, $site4], $siteProvider->getSitesByAccountID(101));
+        $this->assertEquals([], $siteProvider->getSitesByAccountID(451234));
+        $this->assertEquals([$site2, $site3], $siteProvider->getSitesByMultisiteID(500));
+        $this->assertEquals([], $siteProvider->getSitesByMultisiteID(451234));
     }
 }

--- a/tests/MockSitesTest.php
+++ b/tests/MockSitesTest.php
@@ -16,6 +16,9 @@ use PHPUnit\Framework\TestCase;
 class MockSitesTest extends TestCase
 {
     /**
+     * Test that instances of a `MockSite` are shared and not copied.
+     * Additionallity test reading values from a site.
+     *
      * @return void
      */
     public function testSharedInstances()
@@ -36,6 +39,8 @@ class MockSitesTest extends TestCase
     }
 
     /**
+     * Test various methods for fetching filtered lists of sites.
+     *
      * @return void
      */
     public function testGetSitesFiltered()

--- a/tests/OrchSitesTest.php
+++ b/tests/OrchSitesTest.php
@@ -12,7 +12,6 @@ use Garden\Http\Mocks\MockHttpHandler;
 use Garden\Sites\Clients\OrchHttpClient;
 use Garden\Sites\Cluster;
 use Garden\Sites\FileUtils;
-use Garden\Sites\Orch\OrchCluster;
 use Garden\Sites\Orch\OrchSiteProvider;
 use Garden\Sites\Tests\Fixtures\ExpectedSite;
 use Symfony\Component\Cache\Adapter\ArrayAdapter;
@@ -94,6 +93,7 @@ class OrchSitesTest extends BaseSitesTestCase
                 "cl10001",
                 "https://test.vanilla.community/hub",
                 $commonConfigs,
+                100,
             ))->expectRegion(Cluster::REGION_YUL1_DEV1),
 
             4000002 => (new ExpectedSite(
@@ -102,6 +102,7 @@ class OrchSitesTest extends BaseSitesTestCase
                 "cl10001",
                 "https://test.vanilla.community/node1",
                 $commonConfigs,
+                100,
             ))->expectRegion(Cluster::REGION_YUL1_DEV1),
             4000003 => (new ExpectedSite(
                 4000003,

--- a/tests/configs/vanilla.localhost/hub.php
+++ b/tests/configs/vanilla.localhost/hub.php
@@ -1,0 +1,13 @@
+<?php
+/**
+ * @copyright 2009-2023 Vanilla Forums Inc.
+ * @license Proprietary
+ */
+
+$Configuration["Vanilla"]["SiteID"] = 10000;
+$Configuration["Vanilla"]["AccountID"] = 10000;
+$Configuration["EnabledPlugins"]["sitehubshared"] = true;
+$Configuration["APIv2"]["SystemAccessToken"] = "tokenhere";
+$Configuration["Config1"] = "val1";
+$Configuration["Nested"]["Nested1"] = "valnested1";
+$Configuration["Nested"]["Nested2"] = "valnested2";

--- a/tests/configs/vanilla.localhost/node1.php
+++ b/tests/configs/vanilla.localhost/node1.php
@@ -1,0 +1,13 @@
+<?php
+/**
+ * @copyright 2009-2023 Vanilla Forums Inc.
+ * @license Proprietary
+ */
+
+$Configuration["Vanilla"]["SiteID"] = 10001;
+$Configuration["Vanilla"]["AccountID"] = 10000;
+$Configuration["EnabledPlugins"]["sitehubshared"] = true;
+$Configuration["APIv2"]["SystemAccessToken"] = "tokenhere";
+$Configuration["Config1"] = "val1";
+$Configuration["Nested"]["Nested1"] = "valnested1";
+$Configuration["Nested"]["Nested2"] = "valnested2";


### PR DESCRIPTION
https://higherlogic.atlassian.net/browse/VNLA-4485

This PR adds some additional functionality and support into the site providers in order to support the new search service.

## Changes

- Add `Site::getMultisiteID(): int` method.
  - For localhost this is generated automatically based off of the sites hostname.
- Add `SiteProvider::getSitesByMultisiteID(): array` method. 
- Add `SiteProvider::getSitesByAccountID(): array` method. 
- Add tests for these methods.