### PR TITLE
provide a default timeout to prevent aggressive locks

### DIFF
--- a/src/Clients/DashboardHttpClient.php
+++ b/src/Clients/DashboardHttpClient.php
@@ -27,6 +27,7 @@ class DashboardHttpClient extends HttpClient
     {
         parent::__construct($orchBaseUrl);
         $this->setDefaultHeader("content-type", "application/json");
+        $this->setDefaultOption("timeout", 15);
         $this->setThrowExceptions(true);
 
         if ($forcedHostname !== null) {


### PR DESCRIPTION
I added it as a default option instead of a hard coded lock so you could in theory override it when calling the method. 