### PR TITLE
Add timeout for management dashboard API calls

### DIFF
--- a/src/Clients/DashboardHttpClient.php
+++ b/src/Clients/DashboardHttpClient.php
@@ -28,6 +28,8 @@ class DashboardHttpClient extends HttpClient
         parent::__construct($orchBaseUrl);
         $this->setDefaultHeader("content-type", "application/json");
         $this->setThrowExceptions(true);
+        $this->setDefaultOption(HttpRequest::OPT_TIMEOUT, 10);
+        $this->setDefaultOption(HttpRequest::OPT_CONNECT_TIMEOUT, 5);
 
         if ($forcedHostname !== null) {
             HttpUtils::forceForceHostname($this, $forcedHostname);


### PR DESCRIPTION
Those API calls should be pretty fast, and this is often in a performance-critical path, so adding aggressive timeouts.

This should hopefully prevent the search and queue services from timing out at the PHP level, and dying while holding the cache lock and deadlocking the entire PHP-FPM server.

Users of the API client can always adjust this value if a call is expected to be slow.