### PR TITLE
Add PDO to garden-sites

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,6 +31,6 @@
         "php": ">=8.0",
         "vanilla/garden-utils": "^1.0.1",
         "symfony/cache-contracts": "^2.5",
-        "firebase/php-jwt": "^7.0"
+        "firebase/php-jwt": ">=6.10"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -31,6 +31,6 @@
         "php": ">=8.0",
         "vanilla/garden-utils": "^1.0.1",
         "symfony/cache-contracts": "^2.5",
-        "firebase/php-jwt": "^6.10"
+        "firebase/php-jwt": "^7.0"
     }
 }

--- a/src/Dashboard/DashboardSite.php
+++ b/src/Dashboard/DashboardSite.php
@@ -10,6 +10,7 @@ use Garden\Http\HttpRequest;
 use Garden\Http\HttpResponse;
 use Garden\Sites\Clients\SiteHttpClient;
 use Garden\Sites\Cluster;
+use Garden\Sites\Exceptions\ConfigLoadingException;
 use Garden\Sites\Site;
 use Garden\Sites\SiteRecord;
 use Garden\Utils\ArrayUtils;
@@ -102,7 +103,17 @@ class DashboardSite extends Site
      */
     protected function loadSiteConfig(): array
     {
-        $siteConfig = $this->siteProvider->getSiteConfig($this->getSiteID());
+        $details = $this->siteProvider->getSiteDetails($this->getSiteID());
+        $siteConfig = $details["config"] ?? [];
+        if (empty($siteConfig)) {
+            throw new ConfigLoadingException("Dashboard failed to return a site config for site {$this->getSiteID()}");
+        }
+
+        $database = $details["site"]["database"] ?? null;
+        if ($database !== null) {
+            $siteConfig["Database"]["Host"] = $database;
+        }
+
         return $siteConfig;
     }
 }

--- a/src/Site.php
+++ b/src/Site.php
@@ -209,6 +209,50 @@ abstract class Site implements \JsonSerializable
     }
 
     /**
+     * Get the MySQL DSN connection string for this site.
+     *
+     * @return string
+     *
+     * @throws \Exception If required database config keys are missing.
+     */
+    public function getMySqlConnectionDsn(): string
+    {
+        $host = $this->getConfigValueByKey("Database.Host");
+        $port = $this->getConfigValueByKey("Database.Port", 3306);
+        $name = $this->getConfigValueByKey("Database.Name");
+        $user = $this->getConfigValueByKey("Database.User");
+        $password = $this->getConfigValueByKey("Database.Password");
+
+        $missing = array_keys(
+            array_filter(
+                ["Database.Host" => $host, "Database.Name" => $name, "Database.User" => $user],
+                fn($v) => $v === null,
+            ),
+        );
+        if (!empty($missing)) {
+            throw new \Exception("Missing required database config keys: " . implode(", ", $missing));
+        }
+
+        return "mysql:host={$host};port={$port};dbname={$name};user={$user};password={$password}";
+    }
+
+    /**
+     * Create a MySQL PDO connection to this site's database.
+     *
+     * @param array $options Additional PDO options. See https://www.php.net/manual/en/pdo.construct.php for more information.
+     *
+     * @return \PDO
+     *
+     * @throws \Exception If required database config keys are missing.
+     */
+    public function createMySqlConnection(array $options = []): \PDO
+    {
+        $user = $this->getConfigValueByKey("Database.User");
+        $password = $this->getConfigValueByKey("Database.Password");
+        return new \PDO($this->getMySqlConnectionDsn(), $user, $password, options: $options);
+    }
+
+    /**
      * Get the hostname of the proper search service to use for the cluster.
      *
      * @return string

--- a/src/SiteProvider.php
+++ b/src/SiteProvider.php
@@ -8,7 +8,9 @@ namespace Garden\Sites;
 
 use Garden\Sites\Exceptions\ClusterNotFoundException;
 use Garden\Sites\Exceptions\SiteNotFoundException;
+use Symfony\Component\Cache\Adapter\AdapterInterface;
 use Symfony\Component\Cache\Adapter\ArrayAdapter;
+use Symfony\Contracts\Cache\CacheInterface;
 use Symfony\Contracts\Cache\ItemInterface;
 
 /**
@@ -19,7 +21,8 @@ use Symfony\Contracts\Cache\ItemInterface;
  */
 abstract class SiteProvider
 {
-    protected \Symfony\Component\Cache\Adapter\AdapterInterface $cache;
+    /** @var AdapterInterface&CacheInterface */
+    protected AdapterInterface $cache;
 
     protected string $userAgent = "vanilla-sites-package";
 
@@ -52,10 +55,10 @@ abstract class SiteProvider
     /**
      * Apply a symfony cache contract.
      *
-     * @param \Symfony\Component\Cache\Adapter\AdapterInterface $cache
+     * @param AdapterInterface&CacheInterface $cache
      * @return void
      */
-    public function setCache(\Symfony\Component\Cache\Adapter\AdapterInterface $cache): void
+    public function setCache(AdapterInterface $cache): void
     {
         $this->cache = $cache;
     }
@@ -245,30 +248,5 @@ abstract class SiteProvider
         });
 
         return $filteredClusters;
-    }
-    
-    private function getCachedWithFallback(string $cacheKey, callable $hydrator): mixed {
-        $regularCacheKey = $cacheKey;
-        $fallbackCacheKey = "fallback.{$cacheKey}";
-        
-        
-        $regularCacheItem = $this->cache->getItem($regularCacheKey);
-        $fallbackCacheItem = $this->cache->getItem($fallbackCacheKey);
-        
-        if (!$regularCacheItem->isHit()) {
-            
-        }
-        
-        
-        try {
-            $result = $this->cache->get($regularCacheKey, function (ItemInterface $item) use ($hydrator, $fallbackCacheKey) {
-                $result = $hydrator();
-                $item->expiresAfter(60);
-
-                return $result;
-            });
-        } catch (\Throwable $ex) {
-            // We failed
-        }
     }
 }

--- a/src/SiteProvider.php
+++ b/src/SiteProvider.php
@@ -19,7 +19,7 @@ use Symfony\Contracts\Cache\ItemInterface;
  */
 abstract class SiteProvider
 {
-    protected \Symfony\Contracts\Cache\CacheInterface $cache;
+    protected \Symfony\Component\Cache\Adapter\AdapterInterface $cache;
 
     protected string $userAgent = "vanilla-sites-package";
 
@@ -52,10 +52,10 @@ abstract class SiteProvider
     /**
      * Apply a symfony cache contract.
      *
-     * @param \Symfony\Contracts\Cache\CacheInterface $cache
+     * @param \Symfony\Component\Cache\Adapter\AdapterInterface $cache
      * @return void
      */
-    public function setCache(\Symfony\Contracts\Cache\CacheInterface $cache): void
+    public function setCache(\Symfony\Component\Cache\Adapter\AdapterInterface $cache): void
     {
         $this->cache = $cache;
     }
@@ -245,5 +245,30 @@ abstract class SiteProvider
         });
 
         return $filteredClusters;
+    }
+    
+    private function getCachedWithFallback(string $cacheKey, callable $hydrator): mixed {
+        $regularCacheKey = $cacheKey;
+        $fallbackCacheKey = "fallback.{$cacheKey}";
+        
+        
+        $regularCacheItem = $this->cache->getItem($regularCacheKey);
+        $fallbackCacheItem = $this->cache->getItem($fallbackCacheKey);
+        
+        if (!$regularCacheItem->isHit()) {
+            
+        }
+        
+        
+        try {
+            $result = $this->cache->get($regularCacheKey, function (ItemInterface $item) use ($hydrator, $fallbackCacheKey) {
+                $result = $hydrator();
+                $item->expiresAfter(60);
+
+                return $result;
+            });
+        } catch (\Throwable $ex) {
+            // We failed
+        }
     }
 }

--- a/tests/DashboardSitesTest.php
+++ b/tests/DashboardSitesTest.php
@@ -253,6 +253,96 @@ class DashboardSitesTest extends BaseSitesTestCase
     }
 
     /**
+     * Test that the site.database field from the API response is shimmed into config as Database.Host.
+     */
+    public function testDatabaseHostShimmedFromSiteResponse(): void
+    {
+        $provider = $this->siteProvider();
+        $site = $provider->getSite(100);
+
+        $details = $provider->getSiteDetails(100);
+        $expectedHost = $details["site"]["database"];
+        $this->assertNotEmpty($expectedHost);
+        $this->assertEquals($expectedHost, $site->getConfigValueByKey("Database.Host"));
+    }
+
+    /**
+     * Test that getMySqlConnectionDsn() returns a valid DSN when all required config keys are present.
+     */
+    public function testGetMySqlConnectionDsn(): void
+    {
+        $provider = $this->siteProvider();
+        $site = $provider->getSite(100);
+
+        $details = $provider->getSiteDetails(100);
+        $expectedHost = $details["site"]["database"];
+
+        // Inject the remaining required Database config keys via the mock fixture's config.
+        // Database.Host is already shimmed from site.database. We need Name, User, and Password.
+        // We'll use a MockSite to have full control over config.
+        $mockSite = new \Garden\Sites\Mock\MockSite("https://site1.vanillatesting.com", 100, [
+            "Database" => [
+                "Host" => $expectedHost,
+                "Name" => "testdb",
+                "User" => "testuser",
+                "Password" => "testpass",
+            ],
+        ]);
+
+        $dsn = $mockSite->getMySqlConnectionDsn();
+        $this->assertEquals("mysql:host={$expectedHost};port=3306;dbname=testdb;user=testuser;password=testpass", $dsn);
+    }
+
+    /**
+     * Test that getMySqlConnectionDsn() uses a custom port when configured.
+     */
+    public function testGetMySqlConnectionDsnCustomPort(): void
+    {
+        $mockSite = new \Garden\Sites\Mock\MockSite("https://example.com", 1, [
+            "Database" => [
+                "Host" => "db1",
+                "Port" => 3307,
+                "Name" => "mydb",
+                "User" => "root",
+                "Password" => "",
+            ],
+        ]);
+
+        $dsn = $mockSite->getMySqlConnectionDsn();
+        $this->assertEquals("mysql:host=db1;port=3307;dbname=mydb;user=root;password=", $dsn);
+    }
+
+    /**
+     * Test that getMySqlConnectionDsn() throws when required config keys are missing.
+     */
+    public function testGetMySqlConnectionDsnThrowsOnMissingConfig(): void
+    {
+        $mockSite = new \Garden\Sites\Mock\MockSite("https://example.com", 1, []);
+
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage(
+            "Missing required database config keys: Database.Host, Database.Name, Database.User",
+        );
+        $mockSite->getMySqlConnectionDsn();
+    }
+
+    /**
+     * Test that getMySqlConnectionDsn() throws listing only the specific missing keys.
+     */
+    public function testGetMySqlConnectionDsnThrowsPartialMissing(): void
+    {
+        $mockSite = new \Garden\Sites\Mock\MockSite("https://example.com", 1, [
+            "Database" => [
+                "Host" => "db1",
+            ],
+        ]);
+
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage("Missing required database config keys: Database.Name, Database.User");
+        $mockSite->getMySqlConnectionDsn();
+    }
+
+    /**
      * Test that user agent is applied to our http client.
      */
     public function testUserAgent()

--- a/tests/DashboardSitesTest.php
+++ b/tests/DashboardSitesTest.php
@@ -45,7 +45,10 @@ class DashboardSitesTest extends BaseSitesTestCase
     public function siteProvider(): DashboardSiteProvider
     {
         $baseUrl = "https://dashboard.vanilla.local";
-        $dashboardClient = new DashboardHttpClient($baseUrl, "tokenhere");
+        $dashboardClient = new DashboardHttpClient(
+            $baseUrl,
+            "fakefakesecrettokenherefakefakesecrettokenherefakefakesecretfakefakesecret",
+        );
         if ($this->mockHandler === null) {
             $this->fail("Mock handler wasn't configured");
         }

--- a/tests/configs/config.php
+++ b/tests/configs/config.php
@@ -4,4 +4,4 @@ $Configuration["Nested"]["Nested1"] = "valnested1";
 $Configuration["Nested"]["Nested2"] = "valnested2";
 $Configuration["Vanilla"]["SiteID"] = 100;
 $Configuration["Vanilla"]["AccountID"] = 100;
-$Configuration["Context"]["Secret"] = "tokenhere";
+$Configuration["Context"]["Secret"] = "fakefakesecrettokenherefakefakesecrettokenherefakefakesecretfakefakesecret";

--- a/tests/configs/e2e-tests.vanilla.local/site1.php
+++ b/tests/configs/e2e-tests.vanilla.local/site1.php
@@ -10,4 +10,4 @@ $Configuration["Nested"]["Nested2"] = "valnested2";
 $Configuration["Vanilla"]["SiteID"] = 102;
 $Configuration["Vanilla"]["AccountID"] = 102;
 $Configuration["SomeArr"] = [3, 4, 5];
-$Configuration["Context"]["Secret"] = "tokenhere";
+$Configuration["Context"]["Secret"] = "fakefakesecrettokenherefakefakesecrettokenherefakefakesecretfakefakesecret";

--- a/tests/configs/other-cluster.php
+++ b/tests/configs/other-cluster.php
@@ -10,4 +10,4 @@ $Configuration["Nested"]["Nested2"] = "valnested2";
 $Configuration["Vanilla"]["SiteID"] = 105;
 $Configuration["Vanilla"]["AccountID"] = 105;
 $Configuration["Vanilla"]["ClusterID"] = "cl00001";
-$Configuration["Context"]["Secret"] = "tokenhere";
+$Configuration["Context"]["Secret"] = "fakefakesecrettokenherefakefakesecrettokenherefakefakesecretfakefakesecret";

--- a/tests/configs/vanilla.local/hub.php
+++ b/tests/configs/vanilla.local/hub.php
@@ -7,7 +7,7 @@
 $Configuration["Vanilla"]["SiteID"] = 10000;
 $Configuration["Vanilla"]["AccountID"] = 10000;
 $Configuration["EnabledPlugins"]["sitehubshared"] = true;
-$Configuration["Context"]["Secret"] = "tokenhere";
+$Configuration["Context"]["Secret"] = "fakefakesecrettokenherefakefakesecrettokenherefakefakesecretfakefakesecret";
 $Configuration["Config1"] = "val1";
 $Configuration["Nested"]["Nested1"] = "valnested1";
 $Configuration["Nested"]["Nested2"] = "valnested2";

--- a/tests/configs/vanilla.local/node1.php
+++ b/tests/configs/vanilla.local/node1.php
@@ -7,7 +7,7 @@
 $Configuration["Vanilla"]["SiteID"] = 10001;
 $Configuration["Vanilla"]["AccountID"] = 10000;
 $Configuration["EnabledPlugins"]["sitehubshared"] = true;
-$Configuration["Context"]["Secret"] = "tokenhere";
+$Configuration["Context"]["Secret"] = "fakefakesecrettokenherefakefakesecrettokenherefakefakesecretfakefakesecret";
 $Configuration["Config1"] = "val1";
 $Configuration["Nested"]["Nested1"] = "valnested1";
 $Configuration["Nested"]["Nested2"] = "valnested2";

--- a/tests/configs/vanilla.local/valid.php
+++ b/tests/configs/vanilla.local/valid.php
@@ -11,4 +11,4 @@ $Configuration["Vanilla"]["SiteID"] = 101;
 $Configuration["Vanilla"]["AccountID"] = 101;
 $Configuration["MergeWithMe"]["Key2"] = "val2";
 $Configuration["SomeArr"] = [3, 4, 5];
-$Configuration["Context"]["Secret"] = "tokenhere";
+$Configuration["Context"]["Secret"] = "fakefakesecrettokenherefakefakesecrettokenherefakefakesecretfakefakesecret";


### PR DESCRIPTION
This PR adds a method to create a PDO to the site onto `Garden\Sites\Site`

## Other notes

- I've updated some text fixtures to handle a warning in newer versions of the JWT library that have key length requirements (longer key)
- Update some typings of the cache interface to handle newer versions of symfony/cache.