### PR TITLE
Add name and domain support to garden-sites

### DIFF
--- a/src/Dashboard/DashboardSiteProvider.php
+++ b/src/Dashboard/DashboardSiteProvider.php
@@ -69,6 +69,8 @@ class DashboardSiteProvider extends SiteProvider
                 $apiSite["multisiteID"],
                 $apiSite["clusterID"],
                 $apiSite["baseUrl"],
+                $apiSite["name"],
+                $apiSite["domain"] ?? null,
             );
             $site->setExtra("internalBaseUrl", $apiSite["internalBaseUrl"]);
             $site->setExtra("internalHeaders", $apiSite["internalHeaders"]);

--- a/src/Local/LocalSiteProvider.php
+++ b/src/Local/LocalSiteProvider.php
@@ -60,7 +60,7 @@ class LocalSiteProvider extends SiteProvider
 
         $siteRecordsBySiteID = [];
         foreach ($configPaths as $configPath) {
-            $baseUrl = $this->domainForConfigPath($configPath);
+            $baseUrl = $this->baseUrlForConfigPath($configPath);
             if ($baseUrl === null) {
                 continue;
             }
@@ -84,7 +84,16 @@ class LocalSiteProvider extends SiteProvider
                     $multisiteID = null;
                 }
 
-                $siteRecord = new SiteRecord($siteID, $accountID, $multisiteID, $clusterID, $baseUrl);
+                $nameAndDomain = SiteRecord::deriveNameAndDomainFromBaseUrl($baseUrl);
+                $siteRecord = new SiteRecord(
+                    $siteID,
+                    $accountID,
+                    $multisiteID,
+                    $clusterID,
+                    $baseUrl,
+                    $nameAndDomain["name"],
+                    $nameAndDomain["domain"],
+                );
                 $configPath = str_replace($this->siteConfigFsBasePath, "", $configPath);
                 $siteRecord->setExtra("configPath", $configPath);
 
@@ -176,7 +185,7 @@ class LocalSiteProvider extends SiteProvider
      * @param string $configPath
      * @return string|null
      */
-    private function domainForConfigPath(string $configPath): ?string
+    private function baseUrlForConfigPath(string $configPath): ?string
     {
         $configPath = str_replace($this->siteConfigFsBasePath, "", $configPath);
         if (preg_match("/^\\/config.php$/", $configPath)) {

--- a/src/Mock/MockSite.php
+++ b/src/Mock/MockSite.php
@@ -49,7 +49,16 @@ class MockSite extends Site
     ) {
         $this->baseUrl = $baseUrl;
         $this->config = $config;
-        $siteRecord = new SiteRecord($siteID, $accountID, $multisiteID, $clusterID, $baseUrl);
+        $nameAndDomain = SiteRecord::deriveNameAndDomainFromBaseUrl($baseUrl);
+        $siteRecord = new SiteRecord(
+            $siteID,
+            $accountID,
+            $multisiteID,
+            $clusterID,
+            $baseUrl,
+            $nameAndDomain["name"],
+            $nameAndDomain["domain"],
+        );
         parent::__construct($siteRecord, new MockSiteProvider());
         $this->generateKey();
         $this->setSystemToken("test123");

--- a/src/Orch/OrchSiteProvider.php
+++ b/src/Orch/OrchSiteProvider.php
@@ -59,6 +59,8 @@ class OrchSiteProvider extends SiteProvider
                 $apiSite["multisiteid"],
                 $apiSite["cluster"],
                 "https://" . $apiSite["baseurl"],
+                $apiSite["name"],
+                $apiSite["domain"] ?? null,
             );
             $siteRecordsBySiteID[$site->getSiteID()] = $site;
         }

--- a/src/Site.php
+++ b/src/Site.php
@@ -115,6 +115,22 @@ abstract class Site implements \JsonSerializable
     }
 
     /**
+     * @return string
+     */
+    public function getName(): string
+    {
+        return $this->siteRecord->getName();
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getDomain(): ?string
+    {
+        return $this->siteRecord->getDomain();
+    }
+
+    /**
      * Clear the local config cache.
      *
      * @return void

--- a/src/SiteRecord.php
+++ b/src/SiteRecord.php
@@ -27,19 +27,60 @@ class SiteRecord implements \JsonSerializable
 
     private string $baseUrl;
 
+    private string $name;
+
+    private ?string $domain;
+
     /**
      * @param int $siteID
      * @param int $accountID
      * @param string $clusterID
      * @param string $baseUrl
+     * @param string $name
+     * @param string|null $domain
      */
-    public function __construct(int $siteID, int $accountID, ?int $multisiteID, string $clusterID, string $baseUrl)
-    {
+    public function __construct(
+        int $siteID,
+        int $accountID,
+        ?int $multisiteID,
+        string $clusterID,
+        string $baseUrl,
+        string $name,
+        ?string $domain = null
+    ) {
         $this->siteID = $siteID;
         $this->accountID = $accountID;
         $this->multisiteID = $multisiteID;
         $this->clusterID = $clusterID;
         $this->baseUrl = $baseUrl;
+        $this->name = $name;
+        $this->domain = $domain;
+    }
+
+    /**
+     * Derive a site name and domain from a base URL.
+     *
+     * Sites without a path segment use the host as the name with a null domain.
+     * Path-based sites use the host as the domain and a multi-{path} name.
+     *
+     * @return array{name: string, domain: string|null}
+     */
+    public static function deriveNameAndDomainFromBaseUrl(string $baseUrl): array
+    {
+        $host = parse_url($baseUrl, PHP_URL_HOST);
+        $path = trim(parse_url($baseUrl, PHP_URL_PATH) ?? "", "/");
+
+        if ($path === "") {
+            return [
+                "name" => $host,
+                "domain" => null,
+            ];
+        }
+
+        return [
+            "name" => "multi-{$path}.{$host}",
+            "domain" => $host,
+        ];
     }
 
     /**
@@ -92,6 +133,22 @@ class SiteRecord implements \JsonSerializable
     }
 
     /**
+     * @return string
+     */
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getDomain(): ?string
+    {
+        return $this->domain;
+    }
+
+    /**
      * @return UriInterface
      */
     public function getBaseUri(): UriInterface
@@ -133,6 +190,8 @@ class SiteRecord implements \JsonSerializable
             "siteID" => $this->getSiteID(),
             "baseUrl" => $this->getBaseUrl(),
             "clusterID" => $this->getClusterID(),
+            "name" => $this->getName(),
+            "domain" => $this->getDomain(),
         ] + $this->extra;
     }
 }

--- a/tests/DashboardSitesTest.php
+++ b/tests/DashboardSitesTest.php
@@ -119,6 +119,9 @@ class DashboardSitesTest extends BaseSitesTestCase
                 "cl10001",
                 "https://site1.vanillatesting.com",
                 $commonConfigs,
+                null,
+                "site1.vanillatesting.com",
+                null,
             ))->expectRegion(Cluster::REGION_YUL1_DEV1),
             4000001 => (new ExpectedSite(
                 4000001,
@@ -127,6 +130,8 @@ class DashboardSitesTest extends BaseSitesTestCase
                 "https://test.vanilla.community/hub",
                 $commonConfigs,
                 100,
+                "test-hub.vanillatesting.com",
+                "test.vanilla.community",
             ))->expectRegion(Cluster::REGION_YUL1_DEV1),
 
             4000002 => (new ExpectedSite(
@@ -136,6 +141,8 @@ class DashboardSitesTest extends BaseSitesTestCase
                 "https://test.vanilla.community/node1",
                 $commonConfigs,
                 100,
+                "test-node1.vanillatesting.com",
+                "test.vanilla.community",
             ))->expectRegion(Cluster::REGION_YUL1_DEV1),
             4000003 => (new ExpectedSite(
                 4000003,
@@ -143,6 +150,9 @@ class DashboardSitesTest extends BaseSitesTestCase
                 "cl40011",
                 "https://yul1.vanilla.community",
                 $commonConfigs,
+                null,
+                "yul1.vanillatesting.com",
+                "yul1.vanilla.community",
             ))->expectRegion(Cluster::REGION_YUL1_PROD1),
             4000004 => (new ExpectedSite(
                 4000004,
@@ -150,6 +160,9 @@ class DashboardSitesTest extends BaseSitesTestCase
                 "cl40015",
                 "https://ams1.vanilla.community",
                 $commonConfigs,
+                null,
+                "ams1.vanillatesting.com",
+                "ams1.vanilla.community",
             ))->expectRegion(Cluster::REGION_AMS1_PROD1),
             4000005 => (new ExpectedSite(
                 4000005,
@@ -157,6 +170,9 @@ class DashboardSitesTest extends BaseSitesTestCase
                 "cl10001",
                 "https://no-system.vanilla.community",
                 $commonConfigs,
+                null,
+                "no-system.vanillatesting.com",
+                "no-system.vanilla.community",
             ))
                 ->expectNoSystemToken()
                 ->expectRegion(Cluster::REGION_YUL1_DEV1),

--- a/tests/Fixtures/ExpectedSite.php
+++ b/tests/Fixtures/ExpectedSite.php
@@ -28,6 +28,9 @@ class ExpectedSite extends SiteRecord
      * @param string $clusterID
      * @param string $baseUrl
      * @param array $expectedConfigs
+     * @param int|null $multisiteID
+     * @param string|null $name
+     * @param string|null $domain
      */
     public function __construct(
         int $siteID,
@@ -35,9 +38,16 @@ class ExpectedSite extends SiteRecord
         string $clusterID,
         string $baseUrl,
         array $expectedConfigs,
-        ?int $multisiteID = null
+        ?int $multisiteID = null,
+        ?string $name = null,
+        ?string $domain = null
     ) {
-        parent::__construct($siteID, $accountID, $multisiteID, $clusterID, $baseUrl);
+        if ($name === null) {
+            $nameAndDomain = SiteRecord::deriveNameAndDomainFromBaseUrl($baseUrl);
+            $name = $nameAndDomain["name"];
+            $domain = $nameAndDomain["domain"];
+        }
+        parent::__construct($siteID, $accountID, $multisiteID, $clusterID, $baseUrl, $name, $domain);
         $this->expectedConfigs = $expectedConfigs;
     }
 
@@ -72,6 +82,8 @@ class ExpectedSite extends SiteRecord
         TestCase::assertEquals($this->getClusterID(), $site->getClusterID(), "Expected clusterID {$suffix}.");
         TestCase::assertEquals($this->getBaseUrl(), $site->getBaseUrl(), "Expected baseUrl {$suffix}.");
         TestCase::assertEquals($this->getMultisiteID(), $site->getMultisiteID(), "Expected multisiteID {$suffix}.");
+        TestCase::assertEquals($this->getName(), $site->getName(), "Expected name {$suffix}.");
+        TestCase::assertEquals($this->getDomain(), $site->getDomain(), "Expected domain {$suffix}.");
     }
 
     /**

--- a/tests/LocalSitesTest.php
+++ b/tests/LocalSitesTest.php
@@ -168,6 +168,8 @@ class LocalSitesTest extends BaseSitesTestCase
             "siteID": 101,
             "baseUrl": "http:\/\/vanilla.local\/valid",
             "clusterID": "cl00000",
+            "name": "multi-valid.vanilla.local",
+            "domain": "vanilla.local",
             "configPath": "\/vanilla.local\/valid.php"
         }
         JSON;

--- a/tests/mock-dashboard/api/sites/100.json
+++ b/tests/mock-dashboard/api/sites/100.json
@@ -10,6 +10,7 @@
             "Host": "site1.vanillatesting.com"
         },
         "name": "site1.vanillatesting.com",
+        "domain": null,
         "state": "active",
         "database": "dbe1"
     },

--- a/tests/mock-dashboard/api/sites/4000001.json
+++ b/tests/mock-dashboard/api/sites/4000001.json
@@ -10,6 +10,7 @@
             "Host": "test.vanilla.community"
         },
         "name": "test-hub.vanillatesting.com",
+        "domain": "test.vanilla.community",
         "state": "active",
         "database": "db1",
         "multisiteID": null

--- a/tests/mock-dashboard/api/sites/4000002.json
+++ b/tests/mock-dashboard/api/sites/4000002.json
@@ -10,6 +10,7 @@
             "Host": "test.vanilla.community"
         },
         "name": "test-node1.vanillatesting.com",
+        "domain": "test.vanilla.community",
         "state": "active",
         "database": "db1",
         "multisiteID": 100

--- a/tests/mock-dashboard/api/sites/4000003.json
+++ b/tests/mock-dashboard/api/sites/4000003.json
@@ -10,6 +10,7 @@
             "Host": "yul1.vanilla.community"
         },
         "name": "yul1.vanillatesting.com",
+        "domain": "yul1.vanilla.community",
         "state": "active",
         "database": "db1",
         "multisiteID": 100

--- a/tests/mock-dashboard/api/sites/4000004.json
+++ b/tests/mock-dashboard/api/sites/4000004.json
@@ -10,6 +10,7 @@
             "Host": "ams1.vanilla.community"
         },
         "name": "ams1.vanillatesting.com",
+        "domain": "ams1.vanilla.community",
         "state": "active",
         "database": "db1",
         "multisiteID": null

--- a/tests/mock-dashboard/api/sites/4000005.json
+++ b/tests/mock-dashboard/api/sites/4000005.json
@@ -10,6 +10,7 @@
             "Host": "no-system.vanilla.community"
         },
         "name": "no-system.vanillatesting.com",
+        "domain": "no-system.vanilla.community",
         "state": "active",
         "database": "db1",
         "multisiteID": null

--- a/tests/mock-dashboard/api/sites/?regionID%5B0%5D=ams1-prod1&siteState=active.json
+++ b/tests/mock-dashboard/api/sites/?regionID%5B0%5D=ams1-prod1&siteState=active.json
@@ -10,6 +10,7 @@
             "Host": "ams1.vanillatesting.com"
         },
         "name": "ams1.vanillatesting.com",
+        "domain": "ams1.vanilla.community",
         "state": "active",
         "database": "db1",
         "multisiteID": null

--- a/tests/mock-dashboard/api/sites/?regionID%5B0%5D=yul1-dev1&siteState=active.json
+++ b/tests/mock-dashboard/api/sites/?regionID%5B0%5D=yul1-dev1&siteState=active.json
@@ -10,6 +10,7 @@
             "Host": "site1.vanillatesting.com"
         },
         "name": "site1.vanillatesting.com",
+        "domain": null,
         "state": "active",
         "database": "dbe1",
         "multisiteID": null
@@ -25,6 +26,7 @@
             "Host": "test.vanilla.community"
         },
         "name": "test-hub.vanillatesting.com",
+        "domain": "test.vanilla.community",
         "state": "active",
         "database": "db1",
         "multisiteID": 100
@@ -40,6 +42,7 @@
             "Host": "test.vanilla.community"
         },
         "name": "test-node1.vanillatesting.com",
+        "domain": "test.vanilla.community",
         "state": "active",
         "database": "db1",
         "multisiteID": 100
@@ -55,6 +58,7 @@
             "Host": "no-system.vanillatesting.com"
         },
         "name": "no-system.vanillatesting.com",
+        "domain": "no-system.vanilla.community",
         "state": "active",
         "database": "db1",
         "multisiteID": null

--- a/tests/mock-dashboard/api/sites/?regionID%5B0%5D=yul1-prod1&siteState=active.json
+++ b/tests/mock-dashboard/api/sites/?regionID%5B0%5D=yul1-prod1&siteState=active.json
@@ -10,6 +10,7 @@
             "Host": "yul1.vanilla.community"
         },
         "name": "yul1.vanillatesting.com",
+        "domain": "yul1.vanilla.community",
         "state": "active",
         "database": "db1",
         "multisiteID": null


### PR DESCRIPTION
This PR adds `name` and `domain` data into the SiteRecord and Site classes.

This is very straightforward mapping on infrastructure and slightly convoluted on local.