### PR TITLE
Fix site db host in config loading from dashboard

### DIFF
--- a/src/Dashboard/DashboardSite.php
+++ b/src/Dashboard/DashboardSite.php
@@ -110,8 +110,14 @@ class DashboardSite extends Site
         }
 
         $database = $details["site"]["database"] ?? null;
-        if ($database !== null) {
-            $siteConfig["Database"]["Host"] = $database;
+        $regionID = $this->getCluster()->getRegionID();
+        if ($database !== null && $regionID !== null) {
+            $regionSuffix = match ($regionID) {
+                "aws-devlegacy-us-e2" => "vanillafabric.net",
+                default => "vanillaforums.net",
+            };
+
+            $siteConfig["Database"]["Host"] = "{$database}.{$this->getClusterID()}.{$regionID}.{$regionSuffix}";
         }
 
         return $siteConfig;

--- a/src/Dashboard/DashboardSite.php
+++ b/src/Dashboard/DashboardSite.php
@@ -111,7 +111,7 @@ class DashboardSite extends Site
 
         $database = $details["site"]["database"] ?? null;
         $regionID = $this->getCluster()->getRegionID();
-        if ($database !== null && $regionID !== null) {
+        if ($database !== null) {
             $regionSuffix = match ($regionID) {
                 "aws-devlegacy-us-e2" => "vanillafabric.net",
                 default => "vanillaforums.net",

--- a/tests/DashboardSitesTest.php
+++ b/tests/DashboardSitesTest.php
@@ -282,7 +282,7 @@ class DashboardSitesTest extends BaseSitesTestCase
         $details = $provider->getSiteDetails(100);
         $expectedHost = $details["site"]["database"];
         $this->assertNotEmpty($expectedHost);
-        $this->assertEquals($expectedHost, $site->getConfigValueByKey("Database.Host"));
+        $this->assertEquals("dbe1.cl10001.yul1-dev1.vanillaforums.net", $site->getConfigValueByKey("Database.Host"));
     }
 
     /**


### PR DESCRIPTION
We weren't making the full database host name the way we needed to in garden-sites.